### PR TITLE
Include missing files when publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "module": "./index.js",
   "types": "./index.d.ts",
   "files": [
-    "*.js",
-    "*.d.ts",
+    "**/*.js",
+    "**/*.d.ts",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
Before:
<img width="859" height="511" alt="{2CB4BB49-3EAD-4513-8568-4B1DB3E7DF81}" src="https://github.com/user-attachments/assets/b16b6146-aeb8-472f-a0bd-8c82046cb2b1" />

After: 
<img width="845" height="570" alt="{03B77922-FE8E-4DA5-A97A-A2F78D5DF0B5}" src="https://github.com/user-attachments/assets/2f9456b0-a65f-427b-88f9-77af6075a9ac" />


Please publish a new version after merging 
Thanks.

fixes https://github.com/kriasoft/syncguard/issues/1