### PR TITLE
refactor: separate postgres schema setup from backend creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,15 @@ await lock(
 ### Using PostgreSQL
 
 ```typescript
-import { createLock } from "syncguard/postgres";
+import { createLock, setupSchema } from "syncguard/postgres";
 import postgres from "postgres";
 
 const sql = postgres("postgresql://localhost:5432/myapp");
+
+// Setup schema (once, during initialization)
+await setupSchema(sql);
+
+// Create lock function (synchronous)
 const lock = createLock(sql);
 
 await lock(
@@ -146,6 +151,10 @@ const lock = createLock(redis, {
 });
 
 // PostgreSQL
+await setupSchema(sql, {
+  tableName: "app_locks",
+  fenceTableName: "app_fences",
+});
 const lock = createLock(sql, {
   tableName: "app_locks", // Default: "syncguard_locks"
   fenceTableName: "app_fences", // Default: "syncguard_fence_counters"
@@ -160,7 +169,7 @@ const lock = createLock(db, {
 
 ::: warning Backend-Specific Setup
 
-- **PostgreSQL**: Requires indexes on `lock_id` and `expires_at_ms` columns. Tables are auto-created by default.
+- **PostgreSQL**: Call `setupSchema(sql)` once during initialization to create required tables and indexes.
 - **Firestore**: Requires a single-field ascending index on the `lockId` field. See [setup docs](https://kriasoft.com/syncguard/firestore#required-index).
   :::
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,11 +72,19 @@ await lock(workFn, { key: "resource:123" });
 ```
 
 ```typescript [PostgreSQL]
-import { createLock } from "syncguard/postgres";
+import { createLock, setupSchema } from "syncguard/postgres";
 import postgres from "postgres";
 
 const sql = postgres("postgresql://localhost:5432/myapp");
-const lock = await createLock(sql, {
+
+// Setup schema (once, during initialization)
+await setupSchema(sql, {
+  tableName: "app_locks",
+  fenceTableName: "app_fence_counters",
+});
+
+// Create lock function (synchronous)
+const lock = createLock(sql, {
   tableName: "app_locks", // Default: "syncguard_locks"
   fenceTableName: "app_fence_counters", // Default: "syncguard_fence_counters"
 });
@@ -678,6 +686,15 @@ interface PostgresBackendOptions {
 **Usage:**
 
 ```typescript
+import { setupSchema, createPostgresBackend } from "syncguard/postgres";
+
+// Setup schema (once)
+await setupSchema(sql, {
+  tableName: "app_locks",
+  fenceTableName: "app_fence_counters",
+});
+
+// Create backend (synchronous)
 const backend = createPostgresBackend(sql, {
   tableName: "app_locks",
   fenceTableName: "app_fence_counters",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,11 +47,16 @@ await lock(
 ## Quick Start (PostgreSQL)
 
 ```typescript
-import { createLock } from "syncguard/postgres";
+import { createLock, setupSchema } from "syncguard/postgres";
 import postgres from "postgres";
 
 const sql = postgres("postgresql://localhost:5432/myapp");
-const lock = await createLock(sql);
+
+// Setup schema (once, during initialization)
+await setupSchema(sql);
+
+// Create lock function (synchronous)
+const lock = createLock(sql);
 
 await lock(
   async () => {
@@ -61,8 +66,8 @@ await lock(
 );
 ```
 
-::: tip PostgreSQL Indexes Required
-For optimal performance, create indexes on the `lock_id` and `expires_at_ms` fields. See `postgres/schema.sql` for complete table and index definitions.
+::: tip PostgreSQL Schema Setup
+Call `setupSchema()` once during application initialization to create required tables and indexes. This is an idempotent operation safe to call multiple times. See `postgres/schema.sql` for complete table and index definitions.
 :::
 
 ## Quick Start (Firestore)
@@ -118,7 +123,14 @@ const lock = createLock(redis, {
 ```
 
 ```typescript [PostgreSQL]
-const lock = await createLock(sql, {
+// Setup schema with custom table names
+await setupSchema(sql, {
+  tableName: "app_locks",
+  fenceTableName: "app_fence_counters",
+});
+
+// Create lock with matching config
+const lock = createLock(sql, {
   tableName: "app_locks", // Default: "syncguard_locks"
   fenceTableName: "app_fence_counters", // Default: "syncguard_fence_counters"
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncguard",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Functional TypeScript library for distributed locking across microservices. Prevents race conditions with Redis, PostgreSQL, Firestore, and custom backends. Features automatic lock management, timeout handling, and extensible architecture.",
   "keywords": [
     "atomic",

--- a/postgres/config.ts
+++ b/postgres/config.ts
@@ -17,7 +17,6 @@ export function createPostgresConfig(
   const tableName = options.tableName || "syncguard_locks";
   const fenceTableName = options.fenceTableName || "syncguard_fence_counters";
   const cleanupInIsLocked = options.cleanupInIsLocked ?? false;
-  const autoCreateTables = options.autoCreateTables ?? true;
 
   // Validate: fence table must differ from lock table
   if (fenceTableName === tableName) {
@@ -54,6 +53,5 @@ export function createPostgresConfig(
     tableName,
     fenceTableName,
     cleanupInIsLocked,
-    autoCreateTables,
   };
 }

--- a/postgres/types.ts
+++ b/postgres/types.ts
@@ -33,12 +33,6 @@ export interface PostgresBackendOptions {
    * @default false
    */
   cleanupInIsLocked?: boolean;
-
-  /**
-   * Automatically create tables if they don't exist.
-   * @default true
-   */
-  autoCreateTables?: boolean;
 }
 
 /**
@@ -48,7 +42,6 @@ export interface PostgresConfig {
   tableName: string;
   fenceTableName: string;
   cleanupInIsLocked: boolean;
-  autoCreateTables: boolean;
 }
 
 /**

--- a/test/integration/postgres-real.test.ts
+++ b/test/integration/postgres-real.test.ts
@@ -26,6 +26,7 @@ import type { Sql } from "postgres";
 import postgres from "postgres";
 import type { LockBackend } from "../../common/backend.js";
 import { createPostgresBackend } from "../../postgres/backend.js";
+import { setupSchema } from "../../postgres/schema.js";
 import type { PostgresCapabilities } from "../../postgres/types.js";
 
 describe("PostgreSQL Integration Tests", () => {
@@ -55,11 +56,16 @@ describe("PostgreSQL Integration Tests", () => {
       );
     }
 
-    // Create backend with test-specific table names
-    backend = await createPostgresBackend(sql, {
+    // Setup schema with test-specific table names
+    await setupSchema(sql, {
       tableName: `${testTablePrefix}syncguard_locks`,
       fenceTableName: `${testTablePrefix}syncguard_fence_counters`,
-      autoCreateTables: true,
+    });
+
+    // Create backend (synchronous)
+    backend = createPostgresBackend(sql, {
+      tableName: `${testTablePrefix}syncguard_locks`,
+      fenceTableName: `${testTablePrefix}syncguard_fence_counters`,
     });
   });
 


### PR DESCRIPTION
## Summary

Separates PostgreSQL schema initialization from backend creation for clearer setup phase separation and better control.

**Breaking Change**: `createPostgresBackend()` and `createLock()` are now synchronous and no longer auto-create tables.

## Changes

- Add `setupSchema(sql, options?)` function for explicit schema initialization
- Make `createPostgresBackend()` and `createLock()` synchronous (no `await` needed)
- Remove `autoCreateTables` option (use `setupSchema()` instead)
- Update all documentation and examples to show two-phase pattern:
  1. Setup phase: `await setupSchema(sql)`
  2. Usage phase: `const lock = createLock(sql)` (sync)

## Migration

**Before:**
```typescript
const backend = await createPostgresBackend(sql);
const lock = await createLock(sql);
```

**After:**
```typescript
// Once during initialization
await setupSchema(sql);

// Synchronous - can create multiple times
const backend = createPostgresBackend(sql);
const lock = createLock(sql);
```

## Rationale

- **Separation of concerns**: Schema operations are setup tasks, not runtime operations
- **Better DX**: Clear distinction between initialization and usage
- **Synchronous APIs**: Factory functions don't need to be async anymore
- **Explicit control**: Users explicitly choose when to create schema
