### PR TITLE
feat: add AsyncDisposable support for automatic lock cleanup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing! This guide will help you get started.
 - **Bun**: Install from [bun.sh](https://bun.sh)
 - **Docker** (for integration tests): Any recent version
 - **PostgreSQL** (for integration tests): 14+ running on localhost:5432
-- **Node.js**: 18+ (Bun handles this, but good to have)
+- **Node.js**: 20+ (Bun handles this, but good to have)
 
 ## Quick Start
 

--- a/common/backend.ts
+++ b/common/backend.ts
@@ -13,6 +13,7 @@ export { createAutoLock, lock } from "./auto-lock.js";
 export * from "./config.js";
 export * from "./constants.js";
 export * from "./crypto.js";
+export * from "./disposable.js";
 export * from "./errors.js";
 export * from "./helpers.js";
 export * from "./telemetry.js";

--- a/common/disposable.ts
+++ b/common/disposable.ts
@@ -1,0 +1,441 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+/**
+ * AsyncDisposable support for automatic lock cleanup with `await using` syntax.
+ *
+ * Provides RAII (Resource Acquisition Is Initialization) pattern for locks,
+ * ensuring cleanup on all code paths including early returns and exceptions.
+ *
+ * ## Default Error Handling
+ *
+ * **NEW**: Disposal errors are now observable by default to prevent silent failures.
+ * - Development (NODE_ENV !== 'production'): Logs to console.error
+ * - Production: Silent unless SYNCGUARD_DEBUG=true
+ * - Security: Omits sensitive data (key, lockId) from default logs
+ *
+ * **Production Best Practice**: Override with custom callback integrated with your
+ * logging/metrics infrastructure:
+ *
+ * ```typescript
+ * const backend = createRedisBackend(redis, {
+ *   onReleaseError: (err, ctx) => {
+ *     logger.error('Lock disposal failed', { err, ...ctx });
+ *     metrics.increment('syncguard.disposal.error');
+ *   },
+ * });
+ * ```
+ *
+ * ## Configuration Patterns
+ *
+ * There are two independent ways to configure error callbacks, serving different APIs:
+ *
+ * ### Pattern A: Backend-level (for low-level `await using` API)
+ * Configure once at backend creation for all acquisitions:
+ * ```typescript
+ * const backend = createRedisBackend(redis, {
+ *   onReleaseError: (err, ctx) => logger.error("Disposal error", err, ctx),
+ *   disposeTimeoutMs: 5000 // Optional: timeout disposal after 5s
+ * });
+ *
+ * await using lock = await backend.acquire({ key, ttlMs });
+ * // Disposal errors automatically route to backend's onReleaseError
+ * ```
+ *
+ * ### Pattern B: Lock-level (for high-level `lock()` helper)
+ * Configure per-call for fine-grained control:
+ * ```typescript
+ * const backend = createRedisBackend(redis); // Uses default callback
+ *
+ * await lock(backend, {
+ *   key,
+ *   onReleaseError: (err, ctx) => logger.error("Lock error", err, ctx),
+ *   async fn(handle) { ... }
+ * });
+ * ```
+ *
+ * **Note**: These are independent configurations for different usage patterns.
+ * Choose the pattern that matches your API usage - you typically won't mix them.
+ *
+ * @see specs/interface.md#resource-management - Normative specification
+ * @see specs/adrs.md#adr-015-async-raii-for-locks - ADR-015: Async RAII for Locks
+ * @see specs/adrs.md#adr-016-opt-in-disposal-timeout - ADR-016: Opt-In Disposal Timeout
+ */
+
+import type {
+  AcquireOk,
+  AcquireResult,
+  BackendCapabilities,
+  DecoratedAcquireResult,
+  ExtendResult,
+  KeyOp,
+  LockBackend,
+  OnReleaseError,
+  ReleaseResult,
+} from "./types.js";
+
+// Re-export for backward compatibility
+export type { OnReleaseError } from "./types.js";
+
+// ============================================================================
+// Default Error Handler
+// ============================================================================
+
+/**
+ * Default error handler for disposal failures.
+ * Provides safe-by-default observability without requiring user configuration.
+ *
+ * **Behavior**:
+ * - Development (NODE_ENV !== 'production'): Logs all disposal errors to console.error
+ * - Production: Silent by default (unless SYNCGUARD_DEBUG=true environment variable is set)
+ * - Security: Omits sensitive context (key, lockId) from logs by default
+ *
+ * **Important Note**:
+ * - This default handler is ONLY used when no custom `onReleaseError` is provided
+ * - If you provide a custom callback, it will ALWAYS be invoked (regardless of environment)
+ * - The silence behavior only applies to the built-in default handler
+ *
+ * **Production Usage**:
+ * For production systems, strongly recommended to provide a custom onReleaseError callback
+ * that integrates with your logging/metrics infrastructure:
+ *
+ * ```typescript
+ * const backend = createRedisBackend(redis, {
+ *   onReleaseError: (err, ctx) => {
+ *     logger.error('Lock disposal failed', {
+ *       error: err.message,
+ *       source: ctx.source,
+ *       key: ctx.key,
+ *       lockId: ctx.lockId,
+ *     });
+ *     metrics.increment('syncguard.disposal.error', { source: ctx.source });
+ *   },
+ * });
+ * ```
+ *
+ * @see specs/interface.md#error-handling - Error handling best practices
+ * @see specs/adrs.md#adr-015-async-raii-for-locks - Disposal error semantics
+ */
+const defaultDisposalErrorHandler: OnReleaseError = (err, ctx) => {
+  // Only log in development or when explicitly enabled via env var
+  const shouldLog =
+    process.env.NODE_ENV !== "production" ||
+    process.env.SYNCGUARD_DEBUG === "true";
+
+  if (shouldLog) {
+    console.error("[SyncGuard] Lock disposal failed:", {
+      error: err.message,
+      errorName: err.name,
+      source: ctx.source,
+      // Omit key and lockId to avoid leaking sensitive data in logs
+      // Users should provide custom callback for full context
+    });
+  }
+};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Lock handle with resource management methods.
+ * Extends acquire result with release/extend operations and async disposal.
+ */
+export interface DisposableLockHandle {
+  /**
+   * Manually release the lock. Idempotent - safe to call multiple times.
+   * Returns { ok: false } if lock was already released or absent.
+   *
+   * **Error handling**: Throws on system errors (network failures, auth errors)
+   * for consistency with backend API. Only automatic disposal (via `await using`)
+   * swallows errors and routes them to onReleaseError callback.
+   *
+   * @param signal Optional AbortSignal to cancel the release operation
+   * @throws Error on system failures (network timeouts, service unavailable)
+   */
+  release(signal?: AbortSignal): Promise<ReleaseResult>;
+
+  /**
+   * Extend lock TTL. Returns { ok: false } if lock was already released or absent.
+   * @param ttlMs New TTL in milliseconds (resets expiration to now + ttlMs)
+   * @param signal Optional AbortSignal to cancel the extend operation
+   * @throws Error on system failures (network timeouts, service unavailable)
+   */
+  extend(ttlMs: number, signal?: AbortSignal): Promise<ExtendResult>;
+
+  /**
+   * Automatic cleanup on scope exit (used by `await using` syntax).
+   * Never throws - errors are swallowed and optionally routed to onReleaseError callback.
+   */
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
+/**
+ * Successful acquisition with automatic cleanup support.
+ * Use with `await using` for automatic lock release on scope exit.
+ *
+ * @example
+ * ```typescript
+ * await using lock = await backend.acquire({ key, ttlMs: 15_000 });
+ * if (!lock.ok) throw new Error("Failed to acquire lock");
+ * // TypeScript narrows lock to AsyncLock<C> after ok check
+ * await doWork(lock.fence);
+ * // Lock automatically released on scope exit
+ * ```
+ */
+export type AsyncLock<C extends BackendCapabilities> = AcquireOk<C> &
+  DisposableLockHandle;
+
+// ============================================================================
+// Core Factory
+// ============================================================================
+
+/**
+ * Creates a disposable lock handle from a successful acquisition.
+ * Internal utility - use decorateAcquireResult() for public API.
+ *
+ * @param backend Backend operations (release, extend)
+ * @param result Successful acquisition result
+ * @param key Original normalized key for error context
+ * @param onReleaseError Error callback for disposal failures (defaults to defaultDisposalErrorHandler)
+ * @param disposeTimeoutMs Optional timeout for disposal operations in ms
+ * @returns AsyncLock with disposal support
+ */
+export function createDisposableHandle<C extends BackendCapabilities>(
+  backend: Pick<LockBackend<C>, "release" | "extend">,
+  result: AcquireOk<C>,
+  key: string,
+  onReleaseError: OnReleaseError = defaultDisposalErrorHandler,
+  disposeTimeoutMs?: number,
+): AsyncLock<C> {
+  // State machine for disposal idempotency (at-most-once semantics)
+  // Ensures multiple release() or disposal calls don't retry network I/O
+  type State = "active" | "disposing" | "disposed";
+  let state: State = "active";
+  let disposePromise: Promise<void> | null = null;
+
+  const handle: DisposableLockHandle = {
+    async release(signal?: AbortSignal): Promise<ReleaseResult> {
+      // Idempotent: subsequent calls return { ok: false } without network call
+      // This provides at-most-once semantics required by spec
+      if (state === "disposing" || state === "disposed") {
+        return { ok: false };
+      }
+
+      // Mark as disposing before backend call to ensure at-most-once semantics
+      // even if the call throws (network error, timeout, etc.)
+      state = "disposing";
+
+      try {
+        // Throw on errors for consistency with backend API
+        // Only disposal swallows errors (see asyncDispose below)
+        const releaseResult = await backend.release({
+          lockId: result.lockId,
+          signal,
+        });
+        state = "disposed";
+        return releaseResult;
+      } catch (error) {
+        // Release failed - mark as disposed anyway (at-most-once semantics)
+        state = "disposed";
+        throw error;
+      }
+    },
+
+    async extend(ttlMs: number, signal?: AbortSignal): Promise<ExtendResult> {
+      // Note: extend() is NOT idempotent - it's a legitimate operation
+      // to extend multiple times. Don't check state here.
+      return backend.extend({ lockId: result.lockId, ttlMs, signal });
+    },
+
+    async [Symbol.asyncDispose](): Promise<void> {
+      // Idempotent: subsequent calls are no-ops (at-most-once semantics)
+      if (state === "disposed") {
+        return;
+      }
+
+      // Re-entry during disposal: return same promise (idempotent)
+      if (state === "disposing") {
+        return disposePromise!;
+      }
+
+      // First disposal attempt: create and store promise
+      state = "disposing";
+      disposePromise = (async () => {
+        try {
+          // Apply timeout if configured
+          // Note: Timeout only aborts the signal; if the backend doesn't respect
+          // AbortSignal, the operation may still hang. Backends should implement
+          // proper signal handling for timeout to be effective.
+          if (typeof disposeTimeoutMs === "number" && disposeTimeoutMs > 0) {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(
+              () => controller.abort(),
+              disposeTimeoutMs,
+            );
+            try {
+              await backend.release({
+                lockId: result.lockId,
+                signal: controller.signal,
+              });
+            } finally {
+              clearTimeout(timeoutId);
+            }
+          } else {
+            await backend.release({ lockId: result.lockId });
+          }
+          // Success - mark as disposed
+          state = "disposed";
+        } catch (error) {
+          // Disposal failed - mark as disposed anyway (at-most-once semantics)
+          state = "disposed";
+
+          // Never throw from disposal per AsyncDisposable spec
+          // Always notify callback of disposal failure (uses default if not configured)
+          try {
+            // Normalize to Error instance and preserve original for debugging
+            let normalizedError: Error;
+            if (error instanceof Error) {
+              normalizedError = error;
+            } else {
+              normalizedError = new Error(String(error));
+              // Preserve original error for debugging
+              (normalizedError as any).originalError = error;
+            }
+
+            onReleaseError(normalizedError, {
+              lockId: result.lockId,
+              key,
+              source: "disposal",
+            });
+          } catch {
+            // Swallow callback errors - user's callback is responsible for safe error handling
+          }
+          // Error is swallowed - disposal is best-effort cleanup
+        }
+      })();
+
+      return disposePromise;
+    },
+  };
+
+  // Return object with both data and methods
+  // TypeScript sees this as AcquireOk<C> & DisposableLockHandle
+  return Object.assign({}, result, handle) as AsyncLock<C>;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Decorates an acquire result with async disposal support.
+ * This is the main integration point for backends.
+ *
+ * - If acquisition succeeded (ok: true): Returns AsyncLock with disposal methods
+ * - If acquisition failed (ok: false): Returns result with no-op disposal
+ *
+ * **Error Handling**: Disposal errors are routed to the onReleaseError callback.
+ * If not provided, uses defaultDisposalErrorHandler which logs in development
+ * and is silent in production (unless SYNCGUARD_DEBUG=true).
+ *
+ * @param backend Backend instance for release/extend operations
+ * @param result Raw acquisition result from backend
+ * @param key Original normalized key for error context
+ * @param onReleaseError Callback for disposal errors (defaults to defaultDisposalErrorHandler)
+ * @param disposeTimeoutMs Optional timeout for disposal operations in ms
+ * @returns Decorated result with disposal support
+ *
+ * @example
+ * ```typescript
+ * // In backend implementation:
+ * const backend = {
+ *   acquire: async (opts) => {
+ *     const normalizedKey = normalizeAndValidateKey(opts.key);
+ *     const result = await acquireCore(opts);
+ *     return decorateAcquireResult(
+ *       backend,
+ *       result,
+ *       normalizedKey,
+ *       config.onReleaseError,  // Pass through user config or use default
+ *       config.disposeTimeoutMs
+ *     );
+ *   },
+ *   // ...
+ * };
+ * ```
+ */
+export function decorateAcquireResult<C extends BackendCapabilities>(
+  backend: Pick<LockBackend<C>, "release" | "extend">,
+  result: AcquireResult<C>,
+  key: string,
+  onReleaseError: OnReleaseError = defaultDisposalErrorHandler,
+  disposeTimeoutMs?: number,
+): DecoratedAcquireResult<C> {
+  if (!result.ok) {
+    // Failed acquisition: attach no-op methods for await using compatibility
+    const failResult = result as any;
+
+    // No-op disposal for failed acquisitions
+    failResult[Symbol.asyncDispose] = async () => {
+      // No-op - acquisition failed, nothing to clean up
+    };
+
+    // No-op release - returns { ok: false } immediately
+    failResult.release = async () => {
+      return { ok: false };
+    };
+
+    // No-op extend - returns { ok: false } immediately
+    failResult.extend = async () => {
+      return { ok: false };
+    };
+
+    return failResult;
+  }
+
+  // Successful acquisition: create full disposable handle
+  return createDisposableHandle(
+    backend,
+    result,
+    key,
+    onReleaseError,
+    disposeTimeoutMs,
+  );
+}
+
+/**
+ * Optional sugar for fully-typed RAII without manual type narrowing.
+ * Calls backend.acquire() and returns typed handle or failure.
+ *
+ * @param backend Backend instance
+ * @param opts Acquisition options
+ * @returns AsyncLock or failure - no type narrowing needed
+ *
+ * @example
+ * ```typescript
+ * // Option A: Standard (uses TypeScript's built-in narrowing)
+ * await using lock = await backend.acquire({ key, ttlMs });
+ * if (!lock.ok) return;
+ * await lock.extend(5000); // TypeScript knows this is AsyncLock after ok check
+ *
+ * // Option B: Sugar (same narrowing, different API)
+ * await using lock = await acquireHandle(backend, { key, ttlMs });
+ * if (!lock.ok) return;
+ * await lock.extend(5000); // Same narrowing behavior
+ * ```
+ */
+export async function acquireHandle<C extends BackendCapabilities>(
+  backend: LockBackend<C>,
+  opts: KeyOp & { ttlMs: number },
+): Promise<AsyncLock<C> | { ok: false; reason: "locked" }> {
+  const result = await backend.acquire(opts);
+
+  if (!result.ok) {
+    return result;
+  }
+
+  // Result is already decorated by backend, just return it
+  // Type assertion safe here since we checked ok: true
+  return result as AsyncLock<C>;
+}

--- a/common/types.ts
+++ b/common/types.ts
@@ -4,6 +4,8 @@
 /**
  * Core type definitions for the SyncGuard distributed lock library.
  * Defines the backend interface, capabilities, and result types.
+ *
+ * For AsyncDisposable support, see common/disposable.ts
  */
 
 // ============================================================================
@@ -87,6 +89,25 @@ export type AcquireResult<C extends BackendCapabilities> =
     };
 
 /**
+ * Decorated acquire result: includes disposal support for await using.
+ * This is what backends actually return after decorateAcquireResult().
+ *
+ * Failed acquisitions include a no-op disposer for await using compatibility.
+ * Successful acquisitions are AsyncLock<C> with full disposal handle methods.
+ */
+export type DecoratedAcquireResult<C extends BackendCapabilities> =
+  | (AcquireOk<C> & {
+      release(signal?: AbortSignal): Promise<ReleaseResult>;
+      extend(ttlMs: number, signal?: AbortSignal): Promise<ExtendResult>;
+      [Symbol.asyncDispose](): Promise<void>;
+    })
+  | ({ ok: false; reason: "locked" } & {
+      release(): Promise<ReleaseResult>;
+      extend(ttlMs: number): Promise<ExtendResult>;
+      [Symbol.asyncDispose](): Promise<void>;
+    });
+
+/**
  * Release result: no distinction between expired/not-found.
  */
 export type ReleaseResult = { ok: true } | { ok: false };
@@ -133,6 +154,132 @@ export type LockInfoDebug<C extends BackendCapabilities> = LockInfo<C> & {
 // ============================================================================
 
 /**
+ * Callback for release errors during automatic disposal (Symbol.asyncDispose).
+ * Never called for domain outcomes (lock absent) - only for system errors.
+ * Errors are normalized to Error instances before being passed to the callback.
+ *
+ * **IMPORTANT: Automatic Disposal Only**
+ *
+ * This callback is ONLY invoked during automatic disposal via `await using` syntax.
+ * Manual `release()` and `extend()` calls throw errors directly and do NOT use this callback.
+ * This design provides:
+ * - Consistent error handling: Manual operations throw for actionable handling
+ * - RAII safety: Automatic disposal is best-effort cleanup that never throws
+ * - Predictable behavior: Users can rely on manual operations reporting errors immediately
+ *
+ * **CRITICAL: Disposal Error Handling**
+ *
+ * When using `using`/`await using`, disposal errors (including timeouts and cleanup
+ * failures) are ONLY passed to this callback. The disposal process itself never throws
+ * to avoid disrupting your application's control flow. This is your ONLY mechanism to
+ * observe disposal failures without wrapping the entire block in a separate try/catch.
+ *
+ * **Error Handling Patterns:**
+ *
+ * 1. Simple logging:
+ * ```typescript
+ * await using lock = await backend.lock('key', {
+ *   onReleaseError: (err, ctx) => console.error('Disposal failed', err, ctx)
+ * });
+ * ```
+ *
+ * 2. Centralized error tracking:
+ * ```typescript
+ * const globalErrorHandler: OnReleaseError = (err, ctx) => {
+ *   logger.error('Lock release failed', { error: err, ...ctx });
+ *   metrics.increment('lock.release.error', { source: ctx.source });
+ * };
+ * ```
+ *
+ * 3. Combine with telemetry for complete observability:
+ * ```typescript
+ * import { withTelemetry } from 'syncguard/common';
+ *
+ * const backend = withTelemetry(redisBackend, {
+ *   onEvent: (event) => metrics.recordLockOperation(event)
+ * });
+ *
+ * await using lock = await backend.lock('key', {
+ *   onReleaseError: globalErrorHandler
+ * });
+ * ```
+ *
+ * @param error Normalized error that occurred during release (LockError or Error)
+ * @param context Error context with lock identifiers and source (always "disposal")
+ *
+ * @see specs/interface.md#error-handling-patterns - Complete error handling guide
+ */
+export type OnReleaseError = (
+  error: Error,
+  context: {
+    lockId: string;
+    key: string;
+    source: "disposal";
+  },
+) => void;
+
+/**
+ * Common backend configuration options.
+ */
+export interface BackendConfig {
+  /**
+   * Error handler for automatic disposal failures (via `await using`).
+   * Not called for manual release() errors - those are thrown.
+   *
+   * **Important**: This is your only mechanism to observe disposal errors when using
+   * `await using`. Disposal never throws to avoid disrupting control flow.
+   *
+   * Use cases:
+   * - Logging disposal failures for observability
+   * - Metrics/alerting on resource cleanup issues
+   * - Debug mode error reporting
+   *
+   * @example
+   * ```typescript
+   * const backend = createRedisBackend(redis, {
+   *   onReleaseError: (err, ctx) => {
+   *     logger.error('Disposal failed', { error: err, ...ctx });
+   *   }
+   * });
+   * ```
+   *
+   * @see OnReleaseError for error handling patterns
+   * @see specs/interface.md#error-handling-patterns
+   */
+  onReleaseError?: OnReleaseError;
+
+  /**
+   * Timeout for automatic disposal operations in milliseconds.
+   * When set, disposal will abort if the release operation exceeds this duration.
+   *
+   * **Default: undefined (no timeout)**
+   *
+   * Use cases:
+   * - High-reliability systems needing guaranteed disposal responsiveness
+   * - Unreliable network environments (distributed backends)
+   * - Defense against backend client hangs
+   *
+   * **Note**: Most applications should rely on backend client timeouts instead:
+   * - Redis: Configure socket timeout in client options
+   * - PostgreSQL: Use statement_timeout or query_timeout
+   * - Firestore: Configure timeout in client settings
+   *
+   * Only use this when you need disposal-specific timeout behavior independent
+   * of general backend timeouts. Timeout errors are reported via onReleaseError
+   * if configured.
+   *
+   * @example
+   * ```typescript
+   * const backend = createRedisBackend(redis, {
+   *   disposeTimeoutMs: 5000, // Abort disposal after 5s
+   *   onReleaseError: (err, ctx) => logger.warn('Disposal timeout', err, ctx)
+   * });
+   * ```
+   */
+  disposeTimeoutMs?: number;
+}
+
+/**
  * Core lock configuration for the lock() helper.
  */
 export interface LockConfig {
@@ -142,11 +289,25 @@ export interface LockConfig {
   ttlMs?: number;
   /** Abort in-flight operations */
   signal?: AbortSignal;
-  /** Error handler for background release failures */
-  onReleaseError?: (
-    error: Error,
-    context: { lockId: string; key: string },
-  ) => void;
+  /**
+   * Error handler for background release failures during disposal.
+   *
+   * **Critical**: When using `await using`, this callback is your ONLY way to observe
+   * disposal errors. Disposal never throws to avoid disrupting control flow.
+   *
+   * @example
+   * ```typescript
+   * await using lock = await backend.lock('key', {
+   *   onReleaseError: (err, ctx) => {
+   *     logger.error('Failed to release lock', { error: err, ...ctx });
+   *   }
+   * });
+   * ```
+   *
+   * @see OnReleaseError for error handling patterns
+   * @see specs/interface.md#error-handling-patterns
+   */
+  onReleaseError?: OnReleaseError;
 }
 
 /**
@@ -179,8 +340,11 @@ export interface LockBackend<
 > {
   /**
    * Acquire lock atomically. Returns lockId + fence (if supported) or contention.
+   * Result includes disposal methods for `await using` support.
    */
-  acquire: (opts: KeyOp & { ttlMs: number }) => Promise<AcquireResult<C>>;
+  acquire: (
+    opts: KeyOp & { ttlMs: number },
+  ) => Promise<DecoratedAcquireResult<C>>;
 
   /**
    * Release lock by lockId. Returns success or false if absent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,10 @@ layout: home
 hero:
   name: "SyncGuard"
   text: "Distributed locks that feel like local locks"
-  tagline: "One `await lock()` call to prevent race conditions across your services. TypeScript library with fencing tokens, auto-cleanup, and Redis/Firestore/PostgreSQL support."
+  tagline: "One `await lock()` call to prevent race conditions across your services. TypeScript library with fencing tokens, auto-cleanup, and bulletproof concurrency."
+  image:
+    src: /hero.svg
+    alt: SyncGuard - Distributed locking across microservices
   actions:
     - theme: brand
       text: What is SyncGuard?
@@ -30,7 +33,7 @@ features:
   - title: Smart Retries
     icon: 🔁
     details: Exponential backoff with jitter handles contention automatically. Configure max retries, timeout, and backoff strategy to match your needs.
-  - title: Developer Experience
+  - title: Production Ready
     icon: 🎯
-    details: Simple `await lock()` for auto-managed locks or manual control with acquire/release/extend. APIs designed to be hard to misuse.
+    details: Automatic cleanup via `await using`, comprehensive error handling, onReleaseError callbacks, and optional telemetry. Built-in observability for production systems.
 ---

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -196,12 +196,19 @@ Create indexes for **both** tables if using custom names. See `postgres/schema.s
 ### Lock Options
 
 ```ts
-await lock(workFn, {
-  key: "resource:123", // Required: unique identifier
-  ttlMs: 30000, // Lock duration (default: 30s)
-  timeoutMs: 5000, // Max acquisition wait (default: 5s)
-  maxRetries: 10, // Retry attempts (default: 10)
-});
+await lock(
+  async () => {
+    // Your work function
+  },
+  {
+    key: "resource:123", // Required: unique identifier
+    ttlMs: 30000, // Lock duration (default: 30s)
+    acquisition: {
+      timeoutMs: 5000, // Max acquisition wait (default: 5s)
+      maxRetries: 10, // Retry attempts (default: 10)
+    },
+  },
+);
 ```
 
 ## Performance
@@ -465,12 +472,19 @@ Under high contention, PostgreSQL may serialize transactions:
 // SyncGuard automatically retries failed transactions
 // If you see frequent conflicts, adjust retry configuration:
 
-await lock(workFn, {
-  key: "resource:123",
-  maxRetries: 20, // Increase retries
-  retryDelayMs: 200, // Increase delay
-  timeoutMs: 10000, // Increase timeout
-});
+await lock(
+  async () => {
+    // Your work
+  },
+  {
+    key: "resource:123",
+    acquisition: {
+      maxRetries: 20, // Increase retries
+      retryDelayMs: 200, // Increase delay
+      timeoutMs: 10000, // Increase timeout
+    },
+  },
+);
 ```
 
 ### Key Length Limits

--- a/docs/public/hero.svg
+++ b/docs/public/hero.svg
@@ -1,0 +1,129 @@
+<svg viewBox="80 80 440 440" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Gradient for lock -->
+    <linearGradient id="lockGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3c8772;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#2d6657;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Gradient for shield -->
+    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#5fa891;stop-opacity:0.3" />
+      <stop offset="100%" style="stop-color:#3c8772;stop-opacity:0.2" />
+    </linearGradient>
+
+    <!-- Glow effect -->
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Subtle animations -->
+    <style>
+      @keyframes rotate {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+      @keyframes pulse {
+        0%, 100% { opacity: 0.4; }
+        50% { opacity: 0.8; }
+      }
+      @keyframes orbit {
+        0% { transform: rotate(0deg) translateX(180px) rotate(0deg); }
+        100% { transform: rotate(360deg) translateX(180px) rotate(-360deg); }
+      }
+      .orbit-ring {
+        animation: rotate 20s linear infinite;
+        transform-origin: 300px 300px;
+      }
+      .node {
+        animation: pulse 2s ease-in-out infinite;
+      }
+      .node:nth-child(1) { animation-delay: 0s; }
+      .node:nth-child(2) { animation-delay: 0.5s; }
+      .node:nth-child(3) { animation-delay: 1s; }
+      .node:nth-child(4) { animation-delay: 1.5s; }
+
+      /* Theme adaptive colors */
+      @media (prefers-color-scheme: dark) {
+        .node-fill { fill: #2d3748; stroke: #4a5568; }
+        .orbit-stroke { stroke: #3c8772; }
+      }
+      @media (prefers-color-scheme: light) {
+        .node-fill { fill: #ffffff; stroke: #e2e8f0; }
+        .orbit-stroke { stroke: #3c8772; }
+      }
+    </style>
+  </defs>
+
+  <!-- Orbit ring -->
+  <g class="orbit-ring">
+    <circle cx="300" cy="300" r="180" fill="none" class="orbit-stroke" stroke-width="2" opacity="0.2" stroke-dasharray="10 5"/>
+  </g>
+
+  <!-- Orbiting nodes (services) -->
+  <g class="nodes">
+    <g class="node">
+      <circle cx="300" cy="120" r="28" class="node-fill" stroke-width="3" filter="url(#glow)"/>
+      <circle cx="300" cy="120" r="10" fill="#6366f1" opacity="0.6"/>
+    </g>
+
+    <g class="node">
+      <circle cx="480" cy="300" r="28" class="node-fill" stroke-width="3" filter="url(#glow)"/>
+      <circle cx="480" cy="300" r="10" fill="#ec4899" opacity="0.6"/>
+    </g>
+
+    <g class="node">
+      <circle cx="300" cy="480" r="28" class="node-fill" stroke-width="3" filter="url(#glow)"/>
+      <circle cx="300" cy="480" r="10" fill="#f59e0b" opacity="0.6"/>
+    </g>
+
+    <g class="node">
+      <circle cx="120" cy="300" r="28" class="node-fill" stroke-width="3" filter="url(#glow)"/>
+      <circle cx="120" cy="300" r="10" fill="#10b981" opacity="0.6"/>
+    </g>
+  </g>
+
+  <!-- Connection lines to center -->
+  <g opacity="0.3">
+    <line x1="300" y1="120" x2="300" y2="300" class="orbit-stroke" stroke-width="2" stroke-dasharray="5 5"/>
+    <line x1="480" y1="300" x2="300" y2="300" class="orbit-stroke" stroke-width="2" stroke-dasharray="5 5"/>
+    <line x1="300" y1="480" x2="300" y2="300" class="orbit-stroke" stroke-width="2" stroke-dasharray="5 5"/>
+    <line x1="120" y1="300" x2="300" y2="300" class="orbit-stroke" stroke-width="2" stroke-dasharray="5 5"/>
+  </g>
+
+  <!-- Central lock with shield -->
+  <g filter="url(#glow)">
+    <!-- Shield background -->
+    <path d="M 300 200 L 360 220 L 360 300 Q 360 360 300 400 Q 240 360 240 300 L 240 220 Z"
+          fill="url(#shieldGradient)"/>
+
+    <!-- Shield outline -->
+    <path d="M 300 200 L 360 220 L 360 300 Q 360 360 300 400 Q 240 360 240 300 L 240 220 Z"
+          fill="none" stroke="url(#lockGradient)" stroke-width="3" opacity="0.6"/>
+
+    <!-- Lock body -->
+    <rect x="270" y="285" width="60" height="65" rx="8" fill="url(#lockGradient)"/>
+
+    <!-- Lock shackle -->
+    <path d="M 280 285 L 280 265 Q 280 240 300 240 Q 320 240 320 265 L 320 285"
+          fill="none" stroke="url(#lockGradient)" stroke-width="10" stroke-linecap="round"/>
+
+    <!-- Keyhole -->
+    <circle cx="300" cy="305" r="8" fill="#ffffff" opacity="0.9"/>
+    <path d="M 297 305 L 293 330 L 307 330 L 303 305" fill="#ffffff" opacity="0.9"/>
+
+    <!-- Decorative inner glow on lock -->
+    <rect x="272" y="287" width="56" height="61" rx="6" fill="none" stroke="#ffffff" stroke-width="2" opacity="0.2"/>
+  </g>
+
+  <!-- Decorative elements -->
+  <g opacity="0.4">
+    <circle cx="300" cy="180" r="4" fill="url(#lockGradient)"/>
+    <circle cx="285" cy="185" r="3" fill="url(#lockGradient)"/>
+    <circle cx="315" cy="185" r="3" fill="url(#lockGradient)"/>
+  </g>
+</svg>

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -57,12 +57,19 @@ const backend = createRedisBackend(redis, { keyPrefix: prefix });
 ### Lock Options
 
 ```ts
-await lock(workFn, {
-  key: "resource:123", // Required: unique identifier
-  ttlMs: 30000, // Lock duration (default: 30s)
-  timeoutMs: 5000, // Max acquisition wait (default: 5s)
-  maxRetries: 10, // Retry attempts (default: 10)
-});
+await lock(
+  async () => {
+    // Your work function
+  },
+  {
+    key: "resource:123", // Required: unique identifier
+    ttlMs: 30000, // Lock duration (default: 30s)
+    acquisition: {
+      timeoutMs: 5000, // Max acquisition wait (default: 5s)
+      maxRetries: 10, // Retry attempts (default: 10)
+    },
+  },
+);
 ```
 
 ## Performance

--- a/firestore/config.ts
+++ b/firestore/config.ts
@@ -44,5 +44,7 @@ export function createFirestoreConfig(
     fenceCollection,
     cleanupInIsLocked:
       options.cleanupInIsLocked ?? FIRESTORE_DEFAULTS.cleanupInIsLocked,
+    onReleaseError: options.onReleaseError,
+    disposeTimeoutMs: options.disposeTimeoutMs,
   };
 }

--- a/firestore/types.ts
+++ b/firestore/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { BackendCapabilities } from "../common/backend.js";
+import type { OnReleaseError } from "../common/disposable.js";
 
 /**
  * Firestore-specific backend capabilities
@@ -25,6 +26,10 @@ export interface FirestoreBackendOptions {
   fenceCollection?: string;
   /** Enable cleanup in isLocked operation (default: false) */
   cleanupInIsLocked?: boolean;
+  /** Callback for release errors during disposal (optional) */
+  onReleaseError?: OnReleaseError;
+  /** Timeout for automatic disposal operations in ms (optional) */
+  disposeTimeoutMs?: number;
 }
 
 /**
@@ -60,4 +65,6 @@ export interface FirestoreConfig {
   collection: string;
   fenceCollection: string;
   cleanupInIsLocked: boolean;
+  onReleaseError?: OnReleaseError;
+  disposeTimeoutMs?: number;
 }

--- a/index.ts
+++ b/index.ts
@@ -32,11 +32,22 @@ export type {
   TelemetryOptions,
 } from "./common/types.js";
 
+// Resource Management (Async Disposal)
+
+export type {
+  AsyncLock,
+  DisposableLockHandle,
+  OnReleaseError,
+} from "./common/disposable.js";
+
+export { acquireHandle, decorateAcquireResult } from "./common/disposable.js";
+
 // Configuration Constants
 
 export {
   BACKEND_DEFAULTS,
   BACKEND_LIMITS,
+  FENCE_THRESHOLDS,
   LOCK_DEFAULTS,
   MAX_KEY_LENGTH_BYTES,
   RESERVE_BYTES,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncguard",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Functional TypeScript library for distributed locking across microservices. Prevents race conditions with Redis, PostgreSQL, Firestore, and custom backends. Features automatic lock management, timeout handling, and extensible architecture.",
   "keywords": [
     "atomic",
@@ -39,7 +39,7 @@
   "bugs": "https://github.com/kriasoft/syncguard/issues",
   "funding": "https://github.com/sponsors/koistya",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "type": "module",
   "main": "./index.js",

--- a/postgres/backend.ts
+++ b/postgres/backend.ts
@@ -3,6 +3,8 @@
 
 import type { Sql } from "postgres";
 import type { LockBackend } from "../common/backend.js";
+import { decorateAcquireResult } from "../common/disposable.js";
+import { normalizeAndValidateKey } from "../common/validation.js";
 import { createPostgresConfig } from "./config.js";
 import {
   createAcquireOperation,
@@ -57,12 +59,30 @@ export function createPostgresBackend(
     timeAuthority: "server",
   };
 
-  return {
-    acquire: createAcquireOperation(sql, config),
-    release: createReleaseOperation(sql, config),
-    extend: createExtendOperation(sql, config),
+  // Create base operations
+  const acquireCore = createAcquireOperation(sql, config);
+  const releaseOp = createReleaseOperation(sql, config);
+  const extendOp = createExtendOperation(sql, config);
+
+  // Create backend object with disposal support
+  const backend: LockBackend<PostgresCapabilities> = {
+    acquire: async (opts) => {
+      const normalizedKey = normalizeAndValidateKey(opts.key);
+      const result = await acquireCore(opts);
+      return decorateAcquireResult(
+        backend,
+        result,
+        normalizedKey,
+        config.onReleaseError,
+        config.disposeTimeoutMs,
+      );
+    },
+    release: releaseOp,
+    extend: extendOp,
     isLocked: createIsLockedOperation(sql, config),
     lookup: createLookupOperation(sql, config),
     capabilities,
   };
+
+  return backend;
 }

--- a/postgres/config.ts
+++ b/postgres/config.ts
@@ -53,5 +53,7 @@ export function createPostgresConfig(
     tableName,
     fenceTableName,
     cleanupInIsLocked,
+    onReleaseError: options.onReleaseError,
+    disposeTimeoutMs: options.disposeTimeoutMs,
   };
 }

--- a/postgres/types.ts
+++ b/postgres/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { BackendCapabilities } from "../common/backend.js";
+import type { OnReleaseError } from "../common/disposable.js";
 
 /**
  * PostgreSQL backend capabilities with server-side time authority.
@@ -33,6 +34,16 @@ export interface PostgresBackendOptions {
    * @default false
    */
   cleanupInIsLocked?: boolean;
+
+  /**
+   * Callback for release errors during disposal (optional)
+   */
+  onReleaseError?: OnReleaseError;
+
+  /**
+   * Timeout for automatic disposal operations in ms (optional)
+   */
+  disposeTimeoutMs?: number;
 }
 
 /**
@@ -42,6 +53,8 @@ export interface PostgresConfig {
   tableName: string;
   fenceTableName: string;
   cleanupInIsLocked: boolean;
+  onReleaseError?: OnReleaseError;
+  disposeTimeoutMs?: number;
 }
 
 /**

--- a/redis/config.ts
+++ b/redis/config.ts
@@ -45,5 +45,7 @@ export function createRedisConfig(
     keyPrefix,
     cleanupInIsLocked:
       options.cleanupInIsLocked ?? REDIS_DEFAULTS.cleanupInIsLocked,
+    onReleaseError: options.onReleaseError,
+    disposeTimeoutMs: options.disposeTimeoutMs,
   };
 }

--- a/redis/types.ts
+++ b/redis/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { BackendCapabilities } from "../common/backend.js";
+import type { OnReleaseError } from "../common/disposable.js";
 
 /**
  * Redis-specific backend capabilities
@@ -23,6 +24,10 @@ export interface RedisBackendOptions {
   keyPrefix?: string;
   /** Enable cleanup in isLocked operation (default: false) */
   cleanupInIsLocked?: boolean;
+  /** Callback for release errors during disposal (optional) */
+  onReleaseError?: OnReleaseError;
+  /** Timeout for automatic disposal operations in ms (optional) */
+  disposeTimeoutMs?: number;
 }
 
 /**
@@ -47,4 +52,6 @@ export interface LockData {
 export interface RedisConfig {
   keyPrefix: string;
   cleanupInIsLocked: boolean;
+  onReleaseError?: OnReleaseError;
+  disposeTimeoutMs?: number;
 }

--- a/test/integration/disposable.test.ts
+++ b/test/integration/disposable.test.ts
@@ -1,0 +1,553 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration tests for AsyncDisposable support across all backends
+ *
+ * Tests the `await using` pattern with real backend instances:
+ * - Redis backend disposal
+ * - Postgres backend disposal
+ * - Firestore backend disposal
+ * - Error callback integration
+ * - Automatic cleanup on scope exit
+ * - Disposal behavior with errors
+ *
+ * Prerequisites:
+ * - Redis server running on localhost:6379
+ * - PostgreSQL server running on localhost:5432
+ * - Firestore emulator running on localhost:8080
+ */
+
+import { Firestore } from "@google-cloud/firestore";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+import Redis from "ioredis";
+import type { Sql } from "postgres";
+import postgres from "postgres";
+import type { LockBackend, OnReleaseError } from "../../common/types.js";
+import { createFirestoreBackend } from "../../firestore";
+import type { FirestoreCapabilities } from "../../firestore/types.js";
+import { createPostgresBackend, setupSchema } from "../../postgres";
+import type { PostgresCapabilities } from "../../postgres/types.js";
+import { createRedisBackend } from "../../redis";
+import type { RedisCapabilities } from "../../redis/types.js";
+
+describe("AsyncDisposable Integration Tests", () => {
+  // Redis setup
+  let redis: Redis;
+  let redisBackend: LockBackend<RedisCapabilities>;
+
+  // Postgres setup
+  let sql: Sql;
+  let postgresBackend: LockBackend<PostgresCapabilities>;
+
+  // Firestore setup
+  let firestore: Firestore;
+  let firestoreBackend: LockBackend<FirestoreCapabilities>;
+
+  const testKeyPrefix = "test:disposable:";
+
+  beforeAll(async () => {
+    // Setup Redis
+    redis = new Redis({
+      host: "localhost",
+      port: 6379,
+      db: 15,
+      lazyConnect: true,
+    });
+
+    try {
+      await redis.ping();
+    } catch (error) {
+      console.warn("⚠️  Redis not available - Redis tests will fail");
+    }
+
+    // Setup Postgres
+    sql = postgres({
+      host: "localhost",
+      port: 5432,
+      database: "postgres",
+      username: "postgres",
+      password: "postgres",
+    });
+
+    try {
+      await sql`SELECT 1`;
+      // Setup schema before running tests
+      await setupSchema(sql);
+    } catch (error) {
+      console.warn("⚠️  Postgres not available - Postgres tests will fail");
+    }
+
+    // Setup Firestore
+    firestore = new Firestore({
+      projectId: "test-project",
+      host: "localhost:8080",
+      ssl: false,
+      customHeaders: {
+        Authorization: "Bearer owner",
+      },
+    });
+
+    try {
+      await firestore.collection("_health").doc("test").set({ test: true });
+      await firestore.collection("_health").doc("test").delete();
+    } catch (error) {
+      console.warn(
+        "⚠️  Firestore emulator not available - Firestore tests will fail",
+      );
+    }
+  });
+
+  beforeEach(async () => {
+    // Create backends
+    redisBackend = createRedisBackend(redis, { keyPrefix: testKeyPrefix });
+
+    postgresBackend = await createPostgresBackend(sql);
+
+    firestoreBackend = createFirestoreBackend(firestore, {
+      collection: `${testKeyPrefix}locks`,
+      fenceCollection: `${testKeyPrefix}fences`,
+      disposeTimeoutMs: 10000, // Prevent indefinite hangs on CI/CD
+    });
+
+    // Clean up Redis keys
+    try {
+      const keys = await redis.keys(`${testKeyPrefix}*`);
+      if (keys.length > 0) {
+        await redis.del(...keys);
+      }
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+
+    // Clean up Postgres locks
+    try {
+      await sql`DELETE FROM syncguard_locks WHERE key LIKE ${`${testKeyPrefix}%`}`;
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+
+    // Clean up Firestore collections
+    try {
+      const locksDocs = await firestore
+        .collection(`${testKeyPrefix}locks`)
+        .listDocuments();
+      await Promise.all(locksDocs.map((doc) => doc.delete()));
+
+      const fencesDocs = await firestore
+        .collection(`${testKeyPrefix}fences`)
+        .listDocuments();
+      await Promise.all(fencesDocs.map((doc) => doc.delete()));
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up after each test (same as beforeEach)
+    try {
+      const keys = await redis.keys(`${testKeyPrefix}*`);
+      if (keys.length > 0) {
+        await redis.del(...keys);
+      }
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+
+    try {
+      await sql`DELETE FROM syncguard_locks WHERE key LIKE ${`${testKeyPrefix}%`}`;
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+
+    try {
+      const locksDocs = await firestore
+        .collection(`${testKeyPrefix}locks`)
+        .listDocuments();
+      await Promise.all(locksDocs.map((doc) => doc.delete()));
+
+      const fencesDocs = await firestore
+        .collection(`${testKeyPrefix}fences`)
+        .listDocuments();
+      await Promise.all(fencesDocs.map((doc) => doc.delete()));
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  afterAll(async () => {
+    await redis.quit();
+    await sql.end();
+  });
+
+  describe("Redis Backend Disposal", () => {
+    it("should automatically release lock on scope exit", async () => {
+      const key = "redis:auto-release";
+
+      {
+        await using lock = await redisBackend.acquire({ key, ttlMs: 30000 });
+
+        if (lock.ok) {
+          // Lock should be held
+          expect(await redisBackend.isLocked({ key })).toBe(true);
+        }
+      }
+
+      // Lock should be automatically released
+      expect(await redisBackend.isLocked({ key })).toBe(false);
+    });
+
+    it("should release lock even if scope exits with error", async () => {
+      const key = "redis:error-release";
+
+      const testFn = async () => {
+        await using lock = await redisBackend.acquire({ key, ttlMs: 30000 });
+
+        if (lock.ok) {
+          expect(await redisBackend.isLocked({ key })).toBe(true);
+          throw new Error("Test error");
+        }
+      };
+
+      await expect(testFn()).rejects.toThrow("Test error");
+
+      // Lock should still be released
+      expect(await redisBackend.isLocked({ key })).toBe(false);
+    });
+
+    it("should support manual release with disposal handle", async () => {
+      const key = "redis:manual-release";
+
+      await using lock = await redisBackend.acquire({ key, ttlMs: 30000 });
+
+      if (lock.ok) {
+        expect(await redisBackend.isLocked({ key })).toBe(true);
+
+        // Manual release
+        const result = await lock.release();
+        expect(result.ok).toBe(true);
+
+        // Lock should be released
+        expect(await redisBackend.isLocked({ key })).toBe(false);
+      }
+    });
+
+    it("should support extend operation with disposal handle", async () => {
+      const key = "redis:extend";
+
+      await using lock = await redisBackend.acquire({ key, ttlMs: 500 });
+
+      if (lock.ok) {
+        const originalExpiry = lock.expiresAtMs;
+
+        // Wait a bit
+        await Bun.sleep(200);
+
+        // Extend lock
+        const extendResult = await lock.extend(5000);
+        expect(extendResult.ok).toBe(true);
+
+        if (extendResult.ok) {
+          expect(extendResult.expiresAtMs).toBeGreaterThan(originalExpiry);
+        }
+
+        // Wait past original TTL
+        await Bun.sleep(400);
+
+        // Lock should still be held
+        expect(await redisBackend.isLocked({ key })).toBe(true);
+      }
+    });
+
+    it("should invoke onReleaseError callback on disposal failure", async () => {
+      const key = "redis:release-error";
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      // Create backend with error callback
+      const backendWithCallback = createRedisBackend(redis, {
+        keyPrefix: testKeyPrefix,
+        onReleaseError: onReleaseErrorSpy,
+      });
+
+      await using lock = await backendWithCallback.acquire({
+        key,
+        ttlMs: 30000,
+      });
+
+      if (lock.ok) {
+        // Manually delete the lock to cause release to fail
+        await redis.del(`${testKeyPrefix}${key}`);
+        await redis.del(`${testKeyPrefix}id:${lock.lockId}`);
+      }
+
+      // Disposal happens here - should trigger callback since lock is absent
+      // Note: This is a best-effort test - the backend may not actually invoke
+      // the callback if it treats missing locks as successful release
+    });
+
+    it("should handle failed acquisition gracefully", async () => {
+      const key = "redis:contended";
+
+      // Hold lock
+      const firstLock = await redisBackend.acquire({ key, ttlMs: 30000 });
+      expect(firstLock.ok).toBe(true);
+
+      {
+        // Try to acquire same lock (should fail)
+        await using lock = await redisBackend.acquire({ key, ttlMs: 100 });
+
+        expect(lock.ok).toBe(false);
+
+        // No disposal should happen for failed acquisition
+      }
+
+      // First lock should still be held
+      expect(await redisBackend.isLocked({ key })).toBe(true);
+
+      // Clean up
+      if (firstLock.ok) {
+        await firstLock.release();
+      }
+    });
+  });
+
+  describe("Postgres Backend Disposal", () => {
+    it("should automatically release lock on scope exit", async () => {
+      const key = "postgres:auto-release";
+
+      {
+        await using lock = await postgresBackend.acquire({
+          key,
+          ttlMs: 30000,
+        });
+
+        if (lock.ok) {
+          // Lock should be held
+          expect(await postgresBackend.isLocked({ key })).toBe(true);
+        }
+      }
+
+      // Lock should be automatically released
+      expect(await postgresBackend.isLocked({ key })).toBe(false);
+    });
+
+    it("should release lock even if scope exits with error", async () => {
+      const key = "postgres:error-release";
+
+      const testFn = async () => {
+        await using lock = await postgresBackend.acquire({
+          key,
+          ttlMs: 30000,
+        });
+
+        if (lock.ok) {
+          expect(await postgresBackend.isLocked({ key })).toBe(true);
+          throw new Error("Test error");
+        }
+      };
+
+      await expect(testFn()).rejects.toThrow("Test error");
+
+      // Lock should still be released
+      expect(await postgresBackend.isLocked({ key })).toBe(false);
+    });
+
+    it("should support manual release with disposal handle", async () => {
+      const key = "postgres:manual-release";
+
+      await using lock = await postgresBackend.acquire({
+        key,
+        ttlMs: 30000,
+      });
+
+      if (lock.ok) {
+        expect(await postgresBackend.isLocked({ key })).toBe(true);
+
+        // Manual release
+        const result = await lock.release();
+        expect(result.ok).toBe(true);
+
+        // Lock should be released
+        expect(await postgresBackend.isLocked({ key })).toBe(false);
+      }
+    });
+
+    it("should support extend operation with disposal handle", async () => {
+      const key = "postgres:extend";
+
+      await using lock = await postgresBackend.acquire({ key, ttlMs: 500 });
+
+      if (lock.ok) {
+        const originalExpiry = lock.expiresAtMs;
+
+        // Wait a bit
+        await Bun.sleep(200);
+
+        // Extend lock
+        const extendResult = await lock.extend(5000);
+        expect(extendResult.ok).toBe(true);
+
+        if (extendResult.ok) {
+          expect(extendResult.expiresAtMs).toBeGreaterThan(originalExpiry);
+        }
+
+        // Wait past original TTL
+        await Bun.sleep(400);
+
+        // Lock should still be held
+        expect(await postgresBackend.isLocked({ key })).toBe(true);
+      }
+    });
+  });
+
+  describe("Firestore Backend Disposal", () => {
+    it("should automatically release lock on scope exit", async () => {
+      const key = "firestore:auto-release";
+
+      {
+        await using lock = await firestoreBackend.acquire({
+          key,
+          ttlMs: 30000,
+        });
+
+        if (lock.ok) {
+          // Lock should be held
+          expect(await firestoreBackend.isLocked({ key })).toBe(true);
+        }
+      }
+
+      // Lock should be automatically released
+      expect(await firestoreBackend.isLocked({ key })).toBe(false);
+    });
+
+    it("should release lock even if scope exits with error", async () => {
+      const key = "firestore:error-release";
+
+      const testFn = async () => {
+        await using lock = await firestoreBackend.acquire({
+          key,
+          ttlMs: 30000,
+        });
+
+        if (lock.ok) {
+          expect(await firestoreBackend.isLocked({ key })).toBe(true);
+          throw new Error("Test error");
+        }
+      };
+
+      await expect(testFn()).rejects.toThrow("Test error");
+
+      // Lock should still be released
+      expect(await firestoreBackend.isLocked({ key })).toBe(false);
+    });
+
+    it("should support manual release with disposal handle", async () => {
+      const key = "firestore:manual-release";
+
+      await using lock = await firestoreBackend.acquire({
+        key,
+        ttlMs: 30000,
+      });
+
+      if (lock.ok) {
+        expect(await firestoreBackend.isLocked({ key })).toBe(true);
+
+        // Manual release
+        const result = await lock.release();
+        expect(result.ok).toBe(true);
+
+        // Lock should be released
+        expect(await firestoreBackend.isLocked({ key })).toBe(false);
+      }
+    });
+
+    it("should support extend operation with disposal handle", async () => {
+      const key = "firestore:extend";
+
+      await using lock = await firestoreBackend.acquire({ key, ttlMs: 500 });
+
+      if (lock.ok) {
+        const originalExpiry = lock.expiresAtMs;
+
+        // Wait a bit
+        await Bun.sleep(200);
+
+        // Extend lock
+        const extendResult = await lock.extend(5000);
+        expect(extendResult.ok).toBe(true);
+
+        if (extendResult.ok) {
+          expect(extendResult.expiresAtMs).toBeGreaterThan(originalExpiry);
+        }
+
+        // Wait past original TTL
+        await Bun.sleep(400);
+
+        // Lock should still be held
+        expect(await firestoreBackend.isLocked({ key })).toBe(true);
+      }
+    });
+  });
+
+  describe("Cross-backend Consistency", () => {
+    it("should provide consistent disposal behavior across all backends", async () => {
+      const backends = [
+        { name: "Redis", backend: redisBackend },
+        { name: "Postgres", backend: postgresBackend },
+        { name: "Firestore", backend: firestoreBackend },
+      ];
+
+      for (const { name, backend } of backends) {
+        const key = `cross-backend:${name.toLowerCase()}`;
+
+        {
+          await using lock = await backend.acquire({ key, ttlMs: 30000 });
+
+          if (lock.ok) {
+            expect(await backend.isLocked({ key })).toBe(true);
+          }
+        }
+
+        // Lock should be released after disposal
+        expect(await backend.isLocked({ key })).toBe(false);
+      }
+    });
+
+    it("should handle manual operations consistently across backends", async () => {
+      const backends = [
+        { name: "Redis", backend: redisBackend },
+        { name: "Postgres", backend: postgresBackend },
+        { name: "Firestore", backend: firestoreBackend },
+      ];
+
+      for (const { name, backend } of backends) {
+        const key = `manual-ops:${name.toLowerCase()}`;
+
+        await using lock = await backend.acquire({ key, ttlMs: 30000 });
+
+        if (lock.ok) {
+          // Manual release
+          const releaseResult = await lock.release();
+          expect(releaseResult.ok).toBe(true);
+
+          // Subsequent release delegates to backend (returns ok: false - lock absent)
+          const releaseResult2 = await lock.release();
+          expect(releaseResult2.ok).toBe(false);
+
+          // Extend after release delegates to backend (returns ok: false - lock absent)
+          const extendResult = await lock.extend(5000);
+          expect(extendResult.ok).toBe(false);
+        }
+      }
+    });
+  });
+});

--- a/test/integration/firestore-lock.test.ts
+++ b/test/integration/firestore-lock.test.ts
@@ -80,6 +80,9 @@ describe("Firestore Lock Integration Tests", () => {
       const fenceBatch = db.batch();
       fenceDocs.docs.forEach((doc) => fenceBatch.delete(doc.ref));
       if (!fenceDocs.empty) await fenceBatch.commit();
+
+      // Wait for Firestore operations to settle (prevents state leakage between tests)
+      await Bun.sleep(100);
     } catch (error) {
       const message = (error as Error).message;
       if (message.includes("already been terminated")) {
@@ -109,6 +112,9 @@ describe("Firestore Lock Integration Tests", () => {
       const fenceBatch = db.batch();
       fenceDocs.docs.forEach((doc) => fenceBatch.delete(doc.ref));
       if (!fenceDocs.empty) await fenceBatch.commit();
+
+      // Wait for Firestore operations to settle (prevents state leakage between tests)
+      await Bun.sleep(100);
     } catch (error) {
       const message = (error as Error).message;
       if (message.includes("already been terminated")) {

--- a/test/unit/disposable.test.ts
+++ b/test/unit/disposable.test.ts
@@ -1,0 +1,1416 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for AsyncDisposable support (common/disposable.ts)
+ *
+ * Tests the disposal pattern including:
+ * - Idempotent disposal (safe to call multiple times)
+ * - No-op disposal for failed acquisitions
+ * - Error handling and callback invocation
+ * - Error normalization to Error type
+ * - Source field differentiation (disposal vs manual)
+ * - Silent swallowing of callback errors (no logging)
+ * - Integration with acquire result decoration
+ * - Type narrowing via TypeScript discriminated unions
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+import {
+  createDisposableHandle,
+  decorateAcquireResult,
+} from "../../common/disposable.js";
+import type {
+  AcquireOk,
+  AcquireResult,
+  BackendCapabilities,
+  ExtendResult,
+  LockBackend,
+  OnReleaseError,
+  ReleaseResult,
+} from "../../common/types.js";
+
+describe("Disposable Lock Tests", () => {
+  let mockBackend: Pick<
+    LockBackend<BackendCapabilities & { supportsFencing: true }>,
+    "release" | "extend"
+  >;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Spy on console.error to verify callback error logging
+    consoleErrorSpy?.mockRestore();
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    // Create minimal mock backend for disposal tests
+    mockBackend = {
+      release: mock(
+        (): Promise<ReleaseResult> => Promise.resolve({ ok: true }),
+      ),
+      extend: mock(
+        (): Promise<ExtendResult> =>
+          Promise.resolve({ ok: true, expiresAtMs: Date.now() + 30000 }),
+      ),
+    };
+  });
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore();
+  });
+
+  describe("createDisposableHandle", () => {
+    const mockAcquireResult: AcquireOk<
+      BackendCapabilities & { supportsFencing: true }
+    > = {
+      ok: true,
+      lockId: "test-lock-123",
+      expiresAtMs: Date.now() + 30000,
+      fence: "000000000000001",
+    };
+
+    it("should create handle with disposal methods", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      expect(handle).toBeDefined();
+      expect(handle.ok).toBe(true);
+      expect(handle.lockId).toBe("test-lock-123");
+      expect(handle.fence).toBe("000000000000001");
+      expect(typeof handle.release).toBe("function");
+      expect(typeof handle.extend).toBe("function");
+      expect(typeof handle[Symbol.asyncDispose]).toBe("function");
+    });
+
+    it("should call backend.release on manual release()", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      const result = await handle.release();
+
+      expect(result).toEqual({ ok: true });
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-123",
+      });
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+    });
+
+    it("should be idempotent - multiple calls only hit backend once", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // First release succeeds
+      const result1 = await handle.release();
+      expect(result1).toEqual({ ok: true });
+
+      // Subsequent releases are short-circuited (returns ok: false immediately)
+      const result2 = await handle.release();
+      expect(result2).toEqual({ ok: false });
+
+      const result3 = await handle.release();
+      expect(result3).toEqual({ ok: false });
+
+      // Backend called only once (local state tracking for idempotency)
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call backend.extend", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      const result = await handle.extend(15000);
+
+      expect(result.ok).toBe(true);
+      expect(mockBackend.extend).toHaveBeenCalledWith({
+        lockId: "test-lock-123",
+        ttlMs: 15000,
+        signal: undefined,
+      });
+    });
+
+    it("should allow extend() after release (extend is not affected by disposal)", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      await handle.release();
+
+      // Mock backend to return ok: false for extend (lock absent)
+      (mockBackend.extend as ReturnType<typeof mock>).mockResolvedValue({
+        ok: false,
+      });
+
+      const result = await handle.extend(15000);
+
+      // Backend is called (extend is not affected by disposed flag)
+      expect(result).toEqual({ ok: false });
+      expect(mockBackend.extend).toHaveBeenCalledWith({
+        lockId: "test-lock-123",
+        ttlMs: 15000,
+        signal: undefined,
+      });
+    });
+
+    it("should call release() on disposal", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      await handle[Symbol.asyncDispose]();
+
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-123",
+      });
+    });
+
+    it("should never throw from disposal", async () => {
+      const releaseError = new Error("Network failure");
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Disposal should not throw
+      await expect(handle[Symbol.asyncDispose]()).resolves.toBeUndefined();
+    });
+
+    it("should be idempotent - multiple disposal calls only hit backend once", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // First disposal succeeds
+      await handle[Symbol.asyncDispose]();
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+
+      // Second disposal is no-op (doesn't hit backend)
+      await handle[Symbol.asyncDispose]();
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+
+      // Third disposal is also no-op
+      await handle[Symbol.asyncDispose]();
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+    });
+
+    it("should be idempotent - manual release + disposal only hits backend once", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Manual release
+      const result = await handle.release();
+      expect(result).toEqual({ ok: true });
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+
+      // Automatic disposal is no-op (already released)
+      await handle[Symbol.asyncDispose]();
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Error Handling", () => {
+    const mockAcquireResult: AcquireOk<
+      BackendCapabilities & { supportsFencing: true }
+    > = {
+      ok: true,
+      lockId: "test-lock-456",
+      expiresAtMs: Date.now() + 30000,
+      fence: "000000000000002",
+    };
+
+    it("should throw on manual release() for consistency with backend API", async () => {
+      const releaseError = new Error("Network timeout");
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Manual release() should throw exactly like backend.release()
+      await expect(handle.release()).rejects.toThrow("Network timeout");
+    });
+
+    it("should throw on manual release() error (no callback invoked)", async () => {
+      const releaseError = new Error("Redis connection lost");
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        onReleaseErrorSpy,
+      );
+
+      // Manual release() should throw (not swallow)
+      await expect(handle.release()).rejects.toThrow("Redis connection lost");
+
+      // Callback NOT invoked for manual release (only for disposal)
+      expect(onReleaseErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should invoke onReleaseError during disposal with normalized Error", async () => {
+      const releaseError = new Error("Network failure during disposal");
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        onReleaseErrorSpy,
+      );
+
+      // Disposal should invoke callback (not throw)
+      await handle[Symbol.asyncDispose]();
+
+      expect(onReleaseErrorSpy).toHaveBeenCalledTimes(1);
+      expect(onReleaseErrorSpy).toHaveBeenCalledWith(releaseError, {
+        lockId: "test-lock-456",
+        key: "test-key",
+        source: "disposal",
+      });
+    });
+
+    it("should normalize non-Error objects during disposal", async () => {
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      // Throw a string instead of Error
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        "Connection timeout",
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        onReleaseErrorSpy,
+      );
+
+      // Disposal normalizes non-Error to Error
+      await handle[Symbol.asyncDispose]();
+
+      expect(onReleaseErrorSpy).toHaveBeenCalledTimes(1);
+
+      const [error, context] = onReleaseErrorSpy.mock.calls[0]!;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe("Connection timeout");
+      expect(context).toEqual({
+        lockId: "test-lock-456",
+        key: "test-key",
+        source: "disposal",
+      });
+    });
+
+    it("should silently swallow callback errors during disposal without logging", async () => {
+      const releaseError = new Error("Backend error");
+      const callbackError = new Error("Callback failed");
+      const onReleaseErrorSpy = mock<OnReleaseError>(() => {
+        throw callbackError;
+      });
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        onReleaseErrorSpy,
+      );
+
+      // Disposal should not throw despite callback error
+      await handle[Symbol.asyncDispose]();
+
+      expect(onReleaseErrorSpy).toHaveBeenCalledTimes(1);
+      // Callback errors are silently swallowed - no console.error
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not invoke callback when release succeeds", async () => {
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        onReleaseErrorSpy,
+      );
+
+      const result = await handle.release();
+
+      expect(result).toEqual({ ok: true });
+      expect(onReleaseErrorSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should throw on manual release() without callback", async () => {
+      const releaseError = new Error("Network failure");
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        // No callback provided
+      );
+
+      // Manual release() should throw even without callback
+      await expect(handle.release()).rejects.toThrow("Network failure");
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should use default callback that logs in development", async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+
+      const releaseError = new Error("Network failure in dev");
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        // No callback provided - uses default
+      );
+
+      try {
+        // Disposal should not throw (best-effort cleanup)
+        await handle[Symbol.asyncDispose]();
+
+        // Default callback should log in development
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "[SyncGuard] Lock disposal failed:",
+          {
+            error: "Network failure in dev",
+            errorName: "Error",
+            source: "disposal",
+            // Note: key and lockId are omitted for security
+          },
+        );
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
+
+    it("should use default callback that is silent in production", async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalDebug = process.env.SYNCGUARD_DEBUG;
+      process.env.NODE_ENV = "production";
+      delete process.env.SYNCGUARD_DEBUG;
+
+      const releaseError = new Error("Network failure in prod");
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        // No callback provided - uses default
+      );
+
+      try {
+        // Disposal should not throw
+        await handle[Symbol.asyncDispose]();
+
+        // Default callback should NOT log in production
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+        if (originalDebug !== undefined) {
+          process.env.SYNCGUARD_DEBUG = originalDebug;
+        }
+      }
+    });
+
+    it("should use default callback that logs in production when SYNCGUARD_DEBUG=true", async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalDebug = process.env.SYNCGUARD_DEBUG;
+      process.env.NODE_ENV = "production";
+      process.env.SYNCGUARD_DEBUG = "true";
+
+      const releaseError = new Error("Network failure in prod with debug");
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        // No callback provided - uses default
+      );
+
+      try {
+        // Disposal should not throw
+        await handle[Symbol.asyncDispose]();
+
+        // Default callback SHOULD log when SYNCGUARD_DEBUG=true
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "[SyncGuard] Lock disposal failed:",
+          {
+            error: "Network failure in prod with debug",
+            errorName: "Error",
+            source: "disposal",
+          },
+        );
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+        if (originalDebug !== undefined) {
+          process.env.SYNCGUARD_DEBUG = originalDebug;
+        } else {
+          delete process.env.SYNCGUARD_DEBUG;
+        }
+      }
+    });
+
+    it("should allow custom callback to override default", async () => {
+      const customCallback = mock<OnReleaseError>();
+      const releaseError = new Error("Custom callback test");
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        customCallback, // Custom callback provided
+      );
+
+      await handle[Symbol.asyncDispose]();
+
+      // Custom callback should be invoked
+      expect(customCallback).toHaveBeenCalledTimes(1);
+      expect(customCallback).toHaveBeenCalledWith(releaseError, {
+        lockId: "test-lock-456",
+        key: "test-key",
+        source: "disposal",
+      });
+
+      // Default callback should NOT be used
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not log when disposal succeeds (default callback)", async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+
+      // Release succeeds - no error
+      (mockBackend.release as ReturnType<typeof mock>).mockResolvedValue({
+        ok: true,
+      });
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        // No callback - uses default
+      );
+
+      try {
+        await handle[Symbol.asyncDispose]();
+
+        // No error, so default callback should not log
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
+  });
+
+  describe("decorateAcquireResult", () => {
+    it("should attach disposal methods to successful acquisition", async () => {
+      const successResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-789",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000003",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        successResult,
+        "test-key",
+      );
+
+      expect(decorated.ok).toBe(true);
+      if (decorated.ok) {
+        // Type narrowing allows access to disposal methods
+        expect(typeof decorated.release).toBe("function");
+        expect(typeof decorated.extend).toBe("function");
+        expect(typeof decorated[Symbol.asyncDispose]).toBe("function");
+      }
+    });
+
+    it("should attach no-op handle methods to failed acquisition", async () => {
+      const failResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: false,
+        reason: "locked",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        failResult,
+        "test-key",
+      );
+
+      expect(decorated.ok).toBe(false);
+      expect(typeof decorated[Symbol.asyncDispose]).toBe("function");
+      expect(typeof decorated.release).toBe("function");
+      expect(typeof decorated.extend).toBe("function");
+
+      // Disposal should be no-op - no backend calls
+      await decorated[Symbol.asyncDispose]();
+
+      expect(mockBackend.release).not.toHaveBeenCalled();
+    });
+
+    it("should return { ok: false } when calling release() on failed acquisition", async () => {
+      const failResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: false,
+        reason: "locked",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        failResult,
+        "test-key",
+      );
+
+      // Call release() - should return { ok: false } immediately
+      const result = await decorated.release();
+
+      expect(result).toEqual({ ok: false });
+      // No backend call should be made
+      expect(mockBackend.release).not.toHaveBeenCalled();
+    });
+
+    it("should return { ok: false } when calling extend() on failed acquisition", async () => {
+      const failResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: false,
+        reason: "locked",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        failResult,
+        "test-key",
+      );
+
+      // Call extend() - should return { ok: false } immediately
+      const result = await decorated.extend(5000);
+
+      expect(result).toEqual({ ok: false });
+      // No backend call should be made
+      expect(mockBackend.extend).not.toHaveBeenCalled();
+    });
+
+    it("should support multiple calls to release() on failed acquisition", async () => {
+      const failResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: false,
+        reason: "locked",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        failResult,
+        "test-key",
+      );
+
+      // Multiple calls to release() - all should return { ok: false }
+      const result1 = await decorated.release();
+      const result2 = await decorated.release();
+      const result3 = await decorated.release();
+
+      expect(result1).toEqual({ ok: false });
+      expect(result2).toEqual({ ok: false });
+      expect(result3).toEqual({ ok: false });
+      // No backend calls should be made
+      expect(mockBackend.release).not.toHaveBeenCalled();
+    });
+
+    it("should support calling both release() and extend() on failed acquisition", async () => {
+      const failResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: false,
+        reason: "locked",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        failResult,
+        "test-key",
+      );
+
+      // Mix calls to release() and extend()
+      const releaseResult1 = await decorated.release();
+      const extendResult1 = await decorated.extend(5000);
+      const releaseResult2 = await decorated.release();
+      const extendResult2 = await decorated.extend(10000);
+
+      expect(releaseResult1).toEqual({ ok: false });
+      expect(extendResult1).toEqual({ ok: false });
+      expect(releaseResult2).toEqual({ ok: false });
+      expect(extendResult2).toEqual({ ok: false });
+
+      // No backend calls should be made
+      expect(mockBackend.release).not.toHaveBeenCalled();
+      expect(mockBackend.extend).not.toHaveBeenCalled();
+    });
+
+    it("should pass onReleaseError to disposal (not manual release)", async () => {
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+      const releaseError = new Error("Disposal failed");
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const successResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-999",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000004",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        successResult,
+        "test-key",
+        onReleaseErrorSpy,
+      );
+
+      if (decorated.ok) {
+        // Disposal triggers callback
+        await decorated[Symbol.asyncDispose]();
+
+        expect(onReleaseErrorSpy).toHaveBeenCalledWith(releaseError, {
+          lockId: "test-lock-999",
+          key: "test-key",
+          source: "disposal",
+        });
+      }
+    });
+  });
+
+  describe("Type Narrowing", () => {
+    it("should allow access to methods after ok check (successful acquisition)", () => {
+      const successResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-aaa",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000005",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        successResult,
+        "test-key",
+      );
+
+      // After checking ok, TypeScript narrows to AsyncLock
+      if (decorated.ok) {
+        expect(decorated.lockId).toBe("test-lock-aaa");
+        expect(typeof decorated.release).toBe("function");
+        expect(typeof decorated.extend).toBe("function");
+      }
+    });
+
+    it("should have methods on failed acquisition (no runtime errors)", () => {
+      const failResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: false,
+        reason: "locked",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        failResult,
+        "test-key",
+      );
+
+      expect(decorated.ok).toBe(false);
+      if (!decorated.ok) {
+        expect(decorated.reason).toBe("locked");
+        // Methods exist even for failed acquisition
+        expect(typeof decorated.release).toBe("function");
+        expect(typeof decorated.extend).toBe("function");
+      }
+    });
+
+    it("should safely call methods without checking ok (JavaScript safety)", async () => {
+      const failResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: false,
+        reason: "locked",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        failResult,
+        "test-key",
+      );
+
+      // In JavaScript (or with type assertions), someone might forget to check ok
+      // This should NOT throw a runtime error - methods should exist and return { ok: false }
+      const releaseResult = await decorated.release();
+      const extendResult = await decorated.extend(5000);
+
+      expect(releaseResult).toEqual({ ok: false });
+      expect(extendResult).toEqual({ ok: false });
+
+      // No backend calls made
+      expect(mockBackend.release).not.toHaveBeenCalled();
+      expect(mockBackend.extend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("AbortSignal Support", () => {
+    it("should forward signal to backend.release()", async () => {
+      const mockAcquireResult: AcquireOk<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-signal",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000001",
+      };
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      const abortController = new AbortController();
+      await handle.release(abortController.signal);
+
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-signal",
+        signal: abortController.signal,
+      });
+    });
+
+    it("should forward signal to backend.extend()", async () => {
+      const mockAcquireResult: AcquireOk<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-extend-signal",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000002",
+      };
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      const abortController = new AbortController();
+      await handle.extend(15000, abortController.signal);
+
+      expect(mockBackend.extend).toHaveBeenCalledWith({
+        lockId: "test-lock-extend-signal",
+        ttlMs: 15000,
+        signal: abortController.signal,
+      });
+    });
+
+    it("should work without signal parameter (backward compatibility)", async () => {
+      const mockAcquireResult: AcquireOk<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-no-signal",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000003",
+      };
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Call without signal parameter
+      await handle.release();
+
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-no-signal",
+        signal: undefined,
+      });
+    });
+
+    it("should allow different signals for release and extend", async () => {
+      const mockAcquireResult: AcquireOk<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-multi-signal",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000004",
+      };
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      const extendController = new AbortController();
+      await handle.extend(10000, extendController.signal);
+
+      expect(mockBackend.extend).toHaveBeenCalledWith({
+        lockId: "test-lock-multi-signal",
+        ttlMs: 10000,
+        signal: extendController.signal,
+      });
+
+      // Now release with a different signal
+      const releaseController = new AbortController();
+      await handle.release(releaseController.signal);
+
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-multi-signal",
+        signal: releaseController.signal,
+      });
+    });
+  });
+
+  describe("Disposal Timeout", () => {
+    const mockAcquireResult: AcquireOk<
+      BackendCapabilities & { supportsFencing: true }
+    > = {
+      ok: true,
+      lockId: "test-lock-timeout",
+      expiresAtMs: Date.now() + 30000,
+      fence: "000000000000099",
+    };
+
+    it("should abort disposal after timeout", async () => {
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      // Mock release to hang indefinitely
+      (mockBackend.release as ReturnType<typeof mock>).mockImplementation(
+        ({ signal }: { signal?: AbortSignal }) => {
+          return new Promise((_, reject) => {
+            if (signal) {
+              signal.addEventListener("abort", () => {
+                reject(new Error("AbortError: Release operation timed out"));
+              });
+            }
+          });
+        },
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        onReleaseErrorSpy,
+        100, // 100ms timeout
+      );
+
+      // Disposal should complete within timeout window
+      const startTime = Date.now();
+      await handle[Symbol.asyncDispose]();
+      const elapsed = Date.now() - startTime;
+
+      // Should abort around 100ms (allow some margin)
+      expect(elapsed).toBeLessThan(200);
+      expect(elapsed).toBeGreaterThanOrEqual(100);
+
+      // Error callback should be invoked with abort error
+      expect(onReleaseErrorSpy).toHaveBeenCalledTimes(1);
+      const [error, context] = onReleaseErrorSpy.mock.calls[0]!;
+      expect(error.message).toContain("timed out");
+      expect(context).toEqual({
+        lockId: "test-lock-timeout",
+        key: "test-key",
+        source: "disposal",
+      });
+    });
+
+    it("should not timeout when release completes quickly", async () => {
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      // Reset mock to succeed quickly
+      (mockBackend.release as ReturnType<typeof mock>).mockResolvedValue({
+        ok: true,
+      });
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        onReleaseErrorSpy,
+        1000, // 1s timeout
+      );
+
+      const startTime = Date.now();
+      await handle[Symbol.asyncDispose]();
+      const elapsed = Date.now() - startTime;
+
+      // Should complete quickly
+      expect(elapsed).toBeLessThan(100);
+
+      // No error callback invoked
+      expect(onReleaseErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not apply timeout when disposeTimeoutMs is undefined", async () => {
+      // Mock release to complete after 200ms
+      (mockBackend.release as ReturnType<typeof mock>).mockImplementation(
+        () => {
+          return new Promise((resolve) => {
+            setTimeout(() => resolve({ ok: true }), 200);
+          });
+        },
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        undefined, // no callback
+        undefined, // no timeout
+      );
+
+      const startTime = Date.now();
+      await handle[Symbol.asyncDispose]();
+      const elapsed = Date.now() - startTime;
+
+      // Should wait full 200ms
+      expect(elapsed).toBeGreaterThanOrEqual(200);
+    });
+
+    it("should pass signal to manual release when timeout is configured", async () => {
+      const abortController = new AbortController();
+
+      (mockBackend.release as ReturnType<typeof mock>).mockResolvedValue({
+        ok: true,
+      });
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        undefined,
+        1000, // timeout configured but not used for manual release
+      );
+
+      await handle.release(abortController.signal);
+
+      // Manual release uses provided signal, not timeout signal
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-timeout",
+        signal: abortController.signal,
+      });
+    });
+
+    it("should work with decorateAcquireResult", async () => {
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      // Mock release to hang
+      (mockBackend.release as ReturnType<typeof mock>).mockImplementation(
+        ({ signal }: { signal?: AbortSignal }) => {
+          return new Promise((_, reject) => {
+            if (signal) {
+              signal.addEventListener("abort", () => {
+                reject(new Error("AbortError: Timed out"));
+              });
+            }
+          });
+        },
+      );
+
+      const successResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-decorated",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000100",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        successResult,
+        "test-key",
+        onReleaseErrorSpy,
+        100, // 100ms timeout
+      );
+
+      if (decorated.ok) {
+        const startTime = Date.now();
+        await decorated[Symbol.asyncDispose]();
+        const elapsed = Date.now() - startTime;
+
+        expect(elapsed).toBeLessThan(200);
+        expect(onReleaseErrorSpy).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe("Concurrent Disposal and Re-entry", () => {
+    const mockAcquireResult: AcquireOk<
+      BackendCapabilities & { supportsFencing: true }
+    > = {
+      ok: true,
+      lockId: "test-lock-concurrent",
+      expiresAtMs: Date.now() + 30000,
+      fence: "000000000000777",
+    };
+
+    it("should handle concurrent disposal calls (only one backend call)", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Launch multiple concurrent disposal calls
+      const disposalPromises = [
+        handle[Symbol.asyncDispose](),
+        handle[Symbol.asyncDispose](),
+        handle[Symbol.asyncDispose](),
+      ];
+
+      // All should complete successfully
+      await Promise.all(disposalPromises);
+
+      // Backend should be called exactly once
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-concurrent",
+      });
+    });
+
+    it("should return same promise for re-entry during disposal", async () => {
+      // Mock release to be slow (100ms)
+      (mockBackend.release as ReturnType<typeof mock>).mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ ok: true }), 100),
+          ),
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Start first disposal
+      const firstDisposal = handle[Symbol.asyncDispose]();
+
+      // While first disposal is in-flight, start second disposal
+      await Bun.sleep(10); // Give first disposal time to start
+      const secondDisposal = handle[Symbol.asyncDispose]();
+
+      // Both promises should resolve successfully
+      await Promise.all([firstDisposal, secondDisposal]);
+
+      // Backend should be called exactly once
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle mix of concurrent disposal and manual release", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Launch manual release and disposal concurrently
+      const releasePromise = handle.release();
+      const disposalPromise = handle[Symbol.asyncDispose]();
+
+      const [releaseResult] = await Promise.all([
+        releasePromise,
+        disposalPromise,
+      ]);
+
+      // One should succeed, one should return { ok: false }
+      // But backend should only be called once
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+
+      // At least the first call should succeed
+      expect(releaseResult.ok).toBe(true);
+    });
+
+    it("should handle disposal after manual release completes", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Manual release first
+      const releaseResult = await handle.release();
+      expect(releaseResult.ok).toBe(true);
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+
+      // Then disposal (should be no-op)
+      await handle[Symbol.asyncDispose]();
+
+      // Still only one backend call
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle concurrent disposal with error", async () => {
+      const releaseError = new Error("Network failure");
+      const onReleaseErrorSpy = mock<OnReleaseError>();
+
+      (mockBackend.release as ReturnType<typeof mock>).mockRejectedValueOnce(
+        releaseError,
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+        onReleaseErrorSpy,
+      );
+
+      // Launch multiple concurrent disposal calls
+      const disposalPromises = [
+        handle[Symbol.asyncDispose](),
+        handle[Symbol.asyncDispose](),
+        handle[Symbol.asyncDispose](),
+      ];
+
+      // All should complete without throwing
+      await Promise.all(disposalPromises);
+
+      // Backend should be called exactly once
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+
+      // Error callback should be invoked exactly once
+      expect(onReleaseErrorSpy).toHaveBeenCalledTimes(1);
+      expect(onReleaseErrorSpy).toHaveBeenCalledWith(releaseError, {
+        lockId: "test-lock-concurrent",
+        key: "test-key",
+        source: "disposal",
+      });
+    });
+
+    it("should handle rapid sequential disposal calls", async () => {
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Call disposal many times sequentially
+      for (let i = 0; i < 10; i++) {
+        await handle[Symbol.asyncDispose]();
+      }
+
+      // Backend should be called exactly once
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle disposal called during slow release", async () => {
+      // Mock release to be very slow (200ms)
+      (mockBackend.release as ReturnType<typeof mock>).mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ ok: true }), 200),
+          ),
+      );
+
+      const handle = createDisposableHandle(
+        mockBackend,
+        mockAcquireResult,
+        "test-key",
+      );
+
+      // Start disposal
+      const firstDisposal = handle[Symbol.asyncDispose]();
+
+      // Wait a bit, then call disposal again multiple times
+      await Bun.sleep(50);
+      const secondDisposal = handle[Symbol.asyncDispose]();
+      const thirdDisposal = handle[Symbol.asyncDispose]();
+
+      // All should complete successfully
+      await Promise.all([firstDisposal, secondDisposal, thirdDisposal]);
+
+      // Backend should be called exactly once
+      expect(mockBackend.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Integration with await using", () => {
+    it("should support await using pattern for successful acquisition", async () => {
+      const successResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-bbb",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000006",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        successResult,
+        "test-key",
+      ) as AsyncDisposable & typeof successResult;
+
+      // Simulate await using block
+      {
+        await using lock = decorated;
+
+        if (lock.ok) {
+          // Do work with lock
+          expect(lock.lockId).toBe("test-lock-bbb");
+        }
+      }
+
+      // Disposal should have been called automatically
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-bbb",
+      });
+    });
+
+    it("should support await using pattern for failed acquisition", async () => {
+      const failResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: false,
+        reason: "locked",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        failResult,
+        "test-key",
+      ) as AsyncDisposable & typeof failResult;
+
+      // Simulate await using block
+      {
+        await using lock = decorated;
+
+        if (!lock.ok) {
+          // Failed acquisition - no work
+          expect(lock.reason).toBe("locked");
+        }
+      }
+
+      // No release should be called for failed acquisition
+      expect(mockBackend.release).not.toHaveBeenCalled();
+    });
+
+    it("should dispose even if scope exits with error", async () => {
+      const successResult: AcquireResult<
+        BackendCapabilities & { supportsFencing: true }
+      > = {
+        ok: true,
+        lockId: "test-lock-ccc",
+        expiresAtMs: Date.now() + 30000,
+        fence: "000000000000007",
+      };
+
+      const decorated = decorateAcquireResult(
+        mockBackend,
+        successResult,
+        "test-key",
+      ) as AsyncDisposable & typeof successResult;
+
+      const userError = new Error("User code failed");
+
+      const testFn = async () => {
+        await using lock = decorated;
+
+        if (lock.ok) {
+          throw userError;
+        }
+      };
+
+      await expect(testFn()).rejects.toThrow("User code failed");
+
+      // Disposal should still happen despite error
+      expect(mockBackend.release).toHaveBeenCalledWith({
+        lockId: "test-lock-ccc",
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Summary

Adds `await using` syntax support (Node.js ≥20) for RAII-style automatic lock cleanup. Lock handles now implement `Symbol.asyncDispose`, ensuring cleanup on all code paths including early returns and exceptions.

### Key Changes

**AsyncDisposable Implementation** (`common/disposable.ts`)
- New `decorateAcquireResult()` decorator adds disposal support to all acquire operations
- Idempotent disposal with at-most-once semantics (prevents double-release network calls)
- Optional disposal timeout (`disposeTimeoutMs`) for unreliable network environments
- Smart error handling: disposal failures route to `onReleaseError` callback (never throw)

**Default Error Observability**
- Development: Logs disposal errors to `console.error` for visibility
- Production: Silent by default, opt-in via `SYNCGUARD_DEBUG=true`
- Security: Omits sensitive data (key, lockId) from default logs
- Configurable: Override with custom callback for production observability

**Backend Integration**
- All backends updated: Redis, PostgreSQL, Firestore
- `BackendConfig` now accepts `onReleaseError` and `disposeTimeoutMs` options
- Backwards compatible: existing code works unchanged

**Updated Documentation**
- README examples showcase `await using` as primary pattern
- Core concepts guide updated with disposal patterns
- Contributing guide bumps Node.js requirement to 20+
- Comprehensive JSDoc with error handling best practices

### Usage Patterns

**Modern (Node.js ≥20) - Recommended**
```typescript
{
  await using lock = await backend.acquire({ key, ttlMs: 30000 });
  if (lock.ok) {
    await doWork(lock.fence);
    await lock.extend(30000); // Extend if needed
    // Lock automatically released
  }
}
```

**Legacy (Node.js <20) - Still supported**
```typescript
const result = await backend.acquire({ key, ttlMs: 30000 });
if (result.ok) {
  try {
    await doWork(result.fence);
  } finally {
    await backend.release({ lockId: result.lockId });
  }
}
```

**Error Handling Configuration**
```typescript
const backend = createRedisBackend(redis, {
  onReleaseError: (err, ctx) => {
    logger.error('Disposal failed', { err, ...ctx });
    metrics.increment('syncguard.disposal.error');
  },
  disposeTimeoutMs: 5000 // Optional: abort disposal after 5s
});
```

### Testing

- New integration tests: `test/integration/disposable.test.ts`
- New unit tests: `test/unit/disposable.test.ts`
- Coverage: disposal success/failure, idempotency, timeouts, error callbacks
- All backends tested with AsyncDisposable integration

### Architectural Decision

See ADR-015 (Async RAII for Locks) and ADR-016 (Opt-In Disposal Timeout) in `specs/adrs.md` for design rationale.

### Credits

Thanks to [@alii](https://github.com/alii) for proposing the `await using` API!
