### PR TITLE
fix: improve disposal timeout handling for Firestore slowness

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,6 +63,8 @@ jobs:
         run: for i in {1..30}; do nc -z 127.0.0.1 6379 && break || sleep 1; done
       - name: Wait for Postgres (5432)
         run: for i in {1..60}; do nc -z 127.0.0.1 5432 && break || sleep 1; done
+      - name: Wait for Firestore (8080)
+        run: for i in {1..60}; do nc -z 127.0.0.1 8080 && break || sleep 1; done
 
       - run: bun run test:integration
       - run: bun run test:performance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncguard",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Functional TypeScript library for distributed locking across microservices. Prevents race conditions with Redis, PostgreSQL, Firestore, and custom backends. Features automatic lock management, timeout handling, and extensible architecture.",
   "keywords": [
     "atomic",


### PR DESCRIPTION
### Summary

Refactored Promise.race() logic to handle slow in-flight gRPC calls and improve Firestore disposal reliability:

- Refactor Promise.race() to properly handle slow in-flight gRPC calls
- Pre-attach error handler to catch late rejections from aborted promises
- Add Firestore emulator health check to CI workflow (wait for port 8080)
- Adjust test timeouts for Firestore emulator reliability
- Enhance documentation of timeout behavior across backends

This ensures disposal never blocks indefinitely while allowing background RPCs to complete naturally. Errors from delayed operations are routed through onReleaseError callback for observability.

### Changes

- **.github/workflows/integration.yml** - Add Firestore emulator health check before running tests
- **common/disposable.ts** - Improved Promise.race() implementation with better error handling and documentation
- **package.json** - Version bump to 2.5.1
- **test/integration/disposable.test.ts** - Adjusted test timeouts and added polling logic for Firestore

### Test Plan

- [x] All unit tests pass
- [x] Integration tests pending (Firestore timeouts being addressed)
- [x] Type checking passes
- [x] Code formatting is correct